### PR TITLE
workers: fix LSM6DS33 import statement

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -79,7 +79,7 @@ def readIMU(q, b, fake_online_data, init_time, signals_per_sensor, save_dir_init
         if sensor_name == 'ISM330DHCX':
             from adafruit_lsm6ds import ISM330DHCT as Sensor
         elif sensor_name == 'LSM6DS33':
-            from adafruit_lsm6ds.lsm6ds33 import LSM6DS33 as Sensor
+            from adafruit_lsm6ds import LSM6DS33 as Sensor
         elif sensor_name == 'LSM6DS032':
             from adafruit_lsm6ds import LSM6DSOX as Sensor
         else:


### PR DESCRIPTION
Previously, this was failing with a ModuleNotFoundError.

```
Rate: 50.0
Sim length: 300.0
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/RealTimeKin/workers.py", line 82, in readIMU
    from adafruit_lsm6ds.lsm6ds33 import LSM6DS33 as Sensor
ModuleNotFoundError: No module named 'adafruit_lsm6ds.lsm6ds33'; 'adafruit_lsm6ds' is not a package
```
